### PR TITLE
Add a compiler macro to SIMPLE_EBNF to allow the ebnf syntax used in …

### DIFF
--- a/rjs/ecma262.ebnf
+++ b/rjs/ecma262.ebnf
@@ -1,0 +1,473 @@
+//!emitall
+//!emitnone
+
+
+//!emit DoKeyword
+//!emit FunctionCallName
+//!emit IterationDo
+//!emit LogicalNotExpressionOp
+//!emit PostfixExpressionOp
+//!emit PrefixExpressionOp
+//!emit dqstring
+//!emit sqstring
+
+//!emitid SyntaxError					UID_SYNTAXERROR						1
+//!emitid AdditiveOperator				UID_BINARYOPERATOR					2
+//!emitid AdditiveOperator				UID_ADDITIVEOPERATOR				2
+//!emitid MultiplicativeOperator			UID_MULTIPLICATIVEOPERATOR			2
+//!emitid AssignmentOperator				UID_ASSIGNMENTOPERATOR				2
+//!emitid BitwiseANDOperator				UID_BITWISEANDOPERATOR				2
+//!emitid BitwiseNotExpressionOp			UID_BITWISENOTEXPRESSIONOP			2
+//!emitid BitwiseNotOperator				UID_BITWISENOTOPERATOR				2
+//!emitid BitwiseOROperator				UID_BITWISEOROPERATOR				2
+//!emitid BitwiseXOROperator				UID_BITWISEXOROPERATOR				2
+//!emitid LogicalNotOperator				UID_LOGICALNOTOPERATOR				2
+//!emitid LogicalOROperator				UID_LOGICALOROPERATOR				2
+//!emitid LogicalANDOperator				UID_LOGICALANDOPERATOR				2
+//!emitid RelationalOperator				UID_RELATIONALOPERATOR				2
+//!emitid PostfixOperator				UID_POSTFIXOPERATOR					2
+//!emitid PrefixOperator					UID_PREFIXOPERATOR					2
+//!emitid ShiftOperator					UID_SHIFTOPERATOR					2
+//!emitid EqualityOperator				UID_EQUALITYOPERATOR				2
+//!emitid UnaryOperator					UID_UNARYOPERATOR					3
+//!emitid This					 		UID_THIS				 			4
+//!emitid Expression						UID_EXPRESSION						5
+//!emitid LeftHandSideExpression			UID_LEFTHANDSIDEEXPRESSION			6
+//!emitid LeftHandSideExpressionAddr		UID_LEFTHANDSIDEEXPRESSIONADDR		7
+//!emitid AdditiveExpressionOp			UID_ADDITIVEEXPRESSIONOP			8
+//!emitid MultiplicativeExpressionOp		UID_MULTIPLICATIVEEXPRESSIONOP		9
+//!emitid BitwiseANDOp					UID_BITWISEANDOP					10
+//!emitid BitwiseXOROp					UID_BITWISEXOROP					11
+//!emitid BitwiseOROp					UID_BITWISEOROP						12
+//!emitid ShiftExpressionOp				UID_SHIFTEXPRESSIONOP				13
+//!emitid EqualityExpressionOp			UID_EQUALITYEXPRESSIONOP			14
+//!emitid RelationalExpressionOp			UID_RELATIONALEXPRESSIONOP			15
+//!emitid LogicalOROp					UID_LOGICALOROP						16
+//!emitid LogicalANDOp					UID_LOGICALANDOP					17
+//!emitid VariableAllocate				UID_VARIABLEALLOCATE				18
+//!emitid VariableAllocateAndInit		UID_VARIABLEALLOCATEANDINIT			19
+//!emitid IdentifierName					UID_IDENTIFIERNAME					20
+//!emitid Identifier						UID_IDENTIFIER						21
+//!emitid Initialiser					UID_INITIALISER						22
+//!emitid AssignmentExpressionOp			UID_ASSIGNMENTEXPRESSIONOP			23
+//!emitid NewArrayExpression				UID_NEWARRAYEXPRESSION				24
+//!emitid MemberExpressionDotOp			UID_MEMBEREXPRESSIONDOTOP			25
+//!emitid MemberExpressionIndexOp		UID_MEMBEREXPRESSIONINDEXOP			26
+//!emitid FunctionName					UID_FUNCTIONNAME					27
+//!emitid FunctionDeclaration			UID_FUNCTIONDECLARATION				28
+//!emitid FunctionParameter				UID_FUNCTIONPARAMETER				29
+//!emitid FormalParameterList			UID_FORMALPARAMETERLIST				30
+//!emitid FunctionCall					UID_FUNCTIONCALL					32
+//!emitid Argument						UID_ARGUMENT						33
+//!emitid Arguments						UID_ARGUMENTS						34
+//!emitid ReturnStatement				UID_RETURNSTATEMENT					35
+//!emitid DoubleStringCharacters			UID_STRINGCHARACTERS				36
+//!emitid SingleStringCharacters			UID_STRINGCHARACTERS				36
+//!emitid IfStatement					UID_IFSTATEMENT						37
+//!emitid IfConditionOp					UID_IFCONDITIONOP					38
+//!emitid IfTrueStatement				UID_IFTRUESTATEMENT					39
+//!emitid IfFalseStatement				UID_IFFALSESTATEMENT				40
+//!emitid Block							UID_BLOCK							41
+//!emitid IterationFor					UID_ITERATIONFOR					42
+//!emitid ForExpressionInit				UID_FOREXPRESSIONINIT				43
+//!emitid ForExpressionCompare			UID_FOREXPRESSIONCOMPARE			44
+//!emitid ForExpressionIncrement			UID_FOREXPRESSIONINCREMENT			45
+//!emitid ForIterationStatement			UID_FORITERATIONSTATEMENT			46
+//!emitid PostfixExpressionOp			UID_POSTFIXEXPRESSIONOP				47
+//!emitid PrefixExpressionOp				UID_PREFIXEXPRESSIONOP				48
+//!emitid NewExpressionCall				UID_NEWEXPRESSIONCALL				49
+//!emitid FunctionExpression				UID_FUNCTIONEXPRESSION				50
+//!emitid UnaryExpressionOp				UID_UNARYEXPRESSIONOP				51
+//!emitid DecimalIntegerLiteral			UID_DECIMALINTEGERLITERAL			52
+//!emitid DecimalNonIntegerLiteral		UID_DECIMALNONINTEGERLITERAL		53
+//!emitid BreakStatement					UID_BREAKSTATEMENT					54
+//!emitid ContinueStatement				UID_CONTINUESTATEMENT				55
+//!emitid IterationWhile					UID_ITERATIONWHILE					56
+//!emitid IterationDo					UID_ITERATIONDO						57
+//!emitid WhileExpressionCompare			UID_WHILEEXPRESSIONCOMPARE			58
+//!emitid DoWhileExpressionCompare		UID_DOWHILEEXPRESSIONCOMPARE		59
+//!emitid Program 						UID_PROGRAM 						60
+//!emitid StringLiteral					UID_STRINGLITERAL					61
+//!emitid UnaryExpressionDelete			UID_UNARYEXPRESSIONDELETE			62
+//!emitid IterationForIn					UID_ITERATIONFORIN					63
+//!emitid ForInInit						UID_FORININIT						64
+//!emitid UnaryExpressionTypeof			UID_UNARYEXPRESSIONTYPEOF			65
+//!emitid SwitchStatement				UID_SWITCHSTATEMENT					66
+//!emitid SwitchExpression				UID_SWITCHEXPRESSION				67
+//!emitid CaseClause						UID_CASECLAUSE						68
+//!emitid DefaultClause					UID_DEFAULTCLAUSE					69
+//!emitid CaseCode						UID_CASECODE						70
+//!emitid CaseBlock						UID_CASEBLOCK						71
+//!emitid HexIntegerLiteral				UID_HEXINTEGERLITERAL				72
+//!emitid IndexExpression				UID_INDEXEXPRESSION					73
+
+//!abort SC
+
+
+// 6 Source Text
+SourceCharacter		::= .
+
+// 7.2 White space
+WhiteSpace			::= [#x0009] | [#x000B] | [#x000C] | [#x0020] | [#x00A0] | [#xFEFF]
+
+// 7.3 Line Terminators
+LineTerminator			::= [#x000D] [#x000A] | ([#x000A] | [#x000D] | [#x2028] | [#x2029])
+LineTerminatorSequence	::= [#x000D] [#x000A] | [#x000A] | [#x000D] | [#x2028] | [#x2029]
+S					::= ( WhiteSpace | LineTerminator )+
+SC					::= S? ';' S?
+COMMA				::= S? ',' S?
+EQ					::= S? '=' S?
+
+// 7.4 Comments
+Comment				::= MultiLineComment | SingleLineComment
+MultiLineComment		::= '/*' MultiLineCommentChar* '*/'
+MultiLineCommentChar	::= . - '*/'
+SingleLineComment		::= '#' SingleLineCommentChar*
+SingleLineCommentChar	::= SourceCharacter - LineTerminator
+
+// 7.5 Tokens
+Token				::= IdentifierName |
+						NumericLiteral |
+						StringLiteral
+
+// 7.6 Identifier Names and Identifiers
+
+Identifier				::= IdentifierNameNoEmit - (ReservedWord - (ReservedWord IdentifierPart))
+IdentifierNoEmit		::= IdentifierNameNoEmit - (ReservedWord - (ReservedWord IdentifierPart))
+IdentifierName			::= IdentifierStart IdentifierPart*
+IdentifierNameNoEmit	::= IdentifierStart IdentifierPart*
+IdentifierStart			::= UnicodeLetter | '$' | '_' | '\' UnicodeLetter
+UnicodeLetter			::= [#x0041-#x005A] | [#x00C0-#x00DE] | [#x0100-#x0232] | [#x0061-#x007A] | [#x00C0-#x00DE]
+
+Lu					::= [#x0041-#x005A] | [#x00C0-#x00DE] | [#x0100-#x0232]
+Ll					::= [#x0061-#x007A] | [#x00C0-#x00DE]
+IdentifierPart			::= IdentifierStart |
+							UnicodeDigit
+UnicodeDigit			::= [0-9] | [#x0660-#x0669]
+
+ReservedWord			::= NullLiteral |
+							BooleanLiteral |
+							Keyword |
+							FutureReservedWord
+
+Keyword					::= 'instanceof' | 'typeof'	| 'break' |
+							'do' | 'new' | 'var' |
+							'case' | 'else' | 'return' | 'void' |
+							'catch' | 'finally' | 'continue' | 'for' |
+							'switch' | 'while' | 'this' | 'with' |
+							'debugger' | 'function' | 'throw' | 'default' |
+							'if' | 'try' | 'delete' | 'in'
+
+FutureReservedWord			::= 'class' | 'enum' | 'extends' | 'import' | 'const' | 'export' |
+							'implements' | 'let' | 'private' | 'public' |
+							'static' | 'interface' | 'package' | 'protected'
+
+NullLiteral					::= 'null'
+BooleanLiteral 				::= 'true' | 'false'
+Literal 					::= NullLiteral |
+							BooleanLiteral |
+							NumericLiteral |
+							StringLiteral
+
+LiteralOp						::= Literal
+
+// 7.8.3 Numeric Literals
+
+NumericLiteral					::= HexIntegerLiteral | DecimalNonIntegerLiteral | DecimalIntegerLiteral
+DecimalNonIntegerLiteral			::= ('0' | NonZeroDigit DecimalDigits?) '.' DecimalDigits? ExponentPart? |
+								'.' DecimalDigits ExponentPart?
+DecimalIntegerLiteral				::= '0' | NonZeroDigit DecimalDigits? ExponentPart?
+DecimalDigits					::= DecimalDigit+
+DecimalDigit					::= [0-9]
+NonZeroDigit					::= [1-9]
+ExponentPart					::= ExponentIndicator SignedInteger
+ExponentIndicator				::= [eE]
+SignedInteger					::= '-' DecimalDigits |
+								'+' DecimalDigits |
+								DecimalDigits
+HexIntegerLiteral				::= '0' [xX] HexDigit+
+HexDigit						::= [0-9a-fA-F]
+
+// 7.8.4 String Literals
+StringLiteral					::= '"' DoubleStringCharacters? '"' |
+								"'" SingleStringCharacters? "'"
+
+DoubleStringCharacters			::= DoubleStringCharacter+
+SingleStringCharacters			::= SingleStringCharacter+
+
+DoubleStringCharacter			::= SourceCharacter - ('"' | '\\' | LineTerminator)
+
+SingleStringCharacter			::= SourceCharacter - ("'" | '\\' | LineTerminator)
+This							::= 'this'
+
+PrimaryExpression				::= This |
+								'(' S? Expression S? ')' |
+								Literal |
+								Identifier
+
+
+
+
+ArrayLiteral 					::= '[' S? Elision? S? ']' |
+								'[' S? ElementList S? ']' |
+								'[' S? ElementList S? ',' S? Elision S? ']'
+ElementList					::= Elision? S? AssignmentExpression (S? ',' S? Elision? S? AssignmentExpression )*
+Elision						::= ',' S? Elision | S? ','
+
+
+// 11.2 Left-Hand-Side Expressions
+LSB							::= S? '[' S?
+RSB							::= S? ']' S?
+IndexExpression				::= S? '[' S? Expression S? ']' S?
+MemberExpressionBase			::= MemberExpression
+MemberExpressionIndexOp		::= MemberExpressionBase IndexExpression
+MemberExpressionDotOp			::= MemberExpressionBase '.' IdentifierName
+
+MemberExpression 				::= MemberExpressionIndexOp  |
+									MemberExpressionDotOp |
+									FunctionExpression |
+									FunctionCall |
+									PrimaryExpression
+
+NewKeyword					::= 'new' - ('new' IdentifierPart)
+NewExpressionCall				::= NewKeyword S? MemberExpression S? Arguments?
+
+NewExpression 					::= NewExpressionCall |
+								MemberExpression
+
+FunctionCallName				::= MemberExpression
+FunctionCall					::= FunctionCallName S? Arguments
+Arguments						::= '(' S? ')' |
+								'(' S? ArgumentList S? ')'
+Argument						::= AssignmentExpression
+ArgumentList					::= ArgumentList S? ',' S? Argument |
+								Argument
+LeftHandSideExpression			::= NewExpression
+LeftHandSideExpressionAddr		::= NewExpression
+
+
+// 11.3 Postfix Expressions
+// RULE: LeftHandSideExpression always ends up in R0 (Let see if this would work)
+PostfixOperator 				::= '++' | '--'
+PostfixExpressionOp 				::= LeftHandSideExpressionAddr PostfixOperator
+PostfixExpression 				::= PostfixExpressionOp | LeftHandSideExpression
+
+PrefixOperator 					::= '++' | '--'
+PrefixExpressionOp 				::= PrefixOperator LeftHandSideExpressionAddr
+PrefixExpression 				::= PrefixExpressionOp | PostfixExpression
+
+// 11.4 Unary Operators
+UnaryOperator					::= '~' | '!' | ('+' - '++') | ('-' - '--')
+UnaryExpressionOp				::=	S? UnaryOperator S? UnaryExpression
+UnaryExpressionDelete			::=	S? 'delete' S? UnaryExpression
+UnaryExpressionVoid				::=	S? 'void' S? UnaryExpression
+UnaryExpressionTypeof			::=	S? 'typeof' S? UnaryExpression
+UnaryExpression				::=	UnaryExpressionOp | UnaryExpressionDelete | UnaryExpressionTypeof |UnaryExpressionVoid | PrefixExpression
+
+
+// 11.5 Multiplicative Operators
+MultiplicativeOperator 			::= '*' | '/' | '%'
+MultiplicativeExpressionOp		::= MultiplicativeExpression S? MultiplicativeOperator S? UnaryExpression
+MultiplicativeExpression			::= MultiplicativeExpressionOp |
+									UnaryExpression
+
+// 11.6 Additive Operators
+AdditiveOperator 				::= '+' | '-'
+// AbortIfNotMultiplicativeExpression	::= MultiplicativeExpression
+AdditiveExpressionOp			::= AdditiveExpression S? AdditiveOperator S? MultiplicativeExpression
+AdditiveExpression				::= AdditiveExpressionOp |
+									MultiplicativeExpression
+
+
+// 11.7 Bitwise Shift Operators
+ShiftOperator					::= '>>>' | '<<' | '>>'
+ShiftExpressionOp				::= ShiftExpression S? ShiftOperator S? AdditiveExpression
+ShiftExpression					::= ShiftExpressionOp |
+								AdditiveExpression
+
+
+// 11.8 Relational Operators
+RelationalOperator				::= '<=' | '>=' | '<' | '>' | 'instanceof'
+RelationalExpressionOp			::= RelationalExpression S? RelationalOperator S? ShiftExpression
+RelationalExpression				::= RelationalExpressionOp |
+								ShiftExpression
+
+// 11.9 Equality Operators
+EqualityOperator				::= '===' | '==' | '!==' | '!='
+EqualityExpressionOp			::= EqualityExpression S? EqualityOperator S? RelationalExpression
+EqualityExpression				::= EqualityExpressionOp |
+								RelationalExpression
+
+BitwiseANDOperator				::= '&' - '&&'
+BitwiseANDOp					::= BitwiseANDExpression S? BitwiseANDOperator S? EqualityExpression
+BitwiseANDExpression			::= BitwiseANDOp |
+								EqualityExpression
+
+BitwiseXOROperator				::= '^'
+BitwiseXOROp					::= BitwiseXORExpression S? BitwiseXOROperator S? BitwiseANDExpression
+BitwiseXORExpression			::= BitwiseXOROp |
+								BitwiseANDExpression
+
+BitwiseOROperator				::= '|' - '||'
+BitwiseOROp					::= BitwiseORExpression S? BitwiseOROperator S? BitwiseXORExpression
+BitwiseORExpression				::= BitwiseOROp |
+								BitwiseXORExpression
+
+// 11.11 Binary Logical Operators
+LogicalANDOperator				::= '&&'
+LogicalANDOp					::= LogicalANDExpression S? LogicalANDOperator  S? BitwiseORExpression
+LogicalANDExpression			::= LogicalANDOp |
+								BitwiseORExpression
+
+LogicalOROperator				::= '||'
+LogicalOROp					::= LogicalORExpression S? LogicalOROperator S? LogicalANDExpression
+LogicalORExpression				::= LogicalOROp |
+								LogicalANDExpression
+
+
+// 11.12 Conditional Operator ( ? : )
+ConditionalExpression 			::= LogicalORExpression ( S? '?' S? AssignmentExpression S? ':' S? AssignmentExpression )?
+
+// 11.13 Assignment Operators
+AssignmentExpressionOp			::= LeftHandSideExpressionAddr S? AssignmentOperator S? AssignmentExpression
+AssignmentExpression			::= AssignmentExpressionOp | ConditionalExpression
+AssignmentOperator				::= '=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '>>>=' | '&=' | '^=' | '|='
+
+
+// 11.14 Comma Operator 	( , )
+Expression					::= AssignmentExpression ( S? ',' S? AssignmentExpression )*
+
+
+// 12 Statements
+Statement						::= FunctionDeclarationStatement |
+									ExpressionStatement |
+									ContinueStatement |
+									Block |
+									Comment |
+									VariableStatement |
+									EmptyStatement |
+									IfStatement |
+									IterationStatement |
+									ContinueStatement |
+									BreakStatement |
+									ReturnStatement |
+									WithStatement |
+									SwitchStatement
+
+// 12.1 Block
+Block							::= S? '{' S? StatementList? S? '}' S?
+StatementList						::= (S? Statement)+
+
+// 12.2 Variable Statement
+VariableStatement 					::= 'var' S? VariableDeclarationList SC
+VariableDeclarationList				::= VariableDeclaration (COMMA VariableDeclaration )*
+VariableAllocate					::= IdentifierNoEmit
+VariableAllocateAndInit				::= IdentifierNoEmit
+VariableAllocatePush					::= IdentifierNoEmit
+VariableDeclaration					::= VariableAllocateAndInit Initialiser | VariableAllocate
+Initialiser							::= EQ AssignmentExpression
+
+
+// 12.3 Empty Statement
+EmptyStatement					::= S? ';' S?
+
+// 12.4 Expression Statement
+ExpressionStatement 				::= (Expression - ('function' | '{')) SC
+
+
+// 12.5 The if Statement
+//!abort	IfBrackets
+IfBrackets							::= '(' S? Expression S? ')'
+IfConditionOp						::= 'if' S? IfBrackets
+IfTrueStatement					::= Statement
+IfFalseStatement					::= Statement
+IfStatement						::= IfConditionOp S? IfTrueStatement S? 'else' S? IfFalseStatement |
+									IfConditionOp S? IfTrueStatement
+
+// 12.6 Iteration Statements
+// 12.6a Iteration do ... while()
+DoWhileExpressionCompare			::= Expression
+IterationDo						::= 'do' S? Statement S? 'while' S? '(' S? DoWhileExpressionCompare S? ')' SC
+
+// 12.6b Iteration while()
+WhileExpressionCompare				::= Expression
+IterationWhile						::= 'while' S? '(' S? WhileExpressionCompare S? ')' S? Statement
+
+// 12.6c Iteration for ( ; ; )
+ExpressionNoIn						::= Expression
+ForExpressionInit					::= ('var' S? VariableDeclarationList) | ExpressionNoIn
+ForExpressionCompare				::= Expression
+ForExpressionIncrement				::= Expression
+ForIterationStatement				::= Statement
+IterationFor						::= 'for' S? '(' S? ForExpressionInit? S? ';' S? ForExpressionCompare? S? ';' S? ForExpressionIncrement? S? ')' S? ForIterationStatement
+
+// 12.6d Iteration for ( in )
+ForInIterator						::= ('var' S? VariableAllocateAndInit) | LeftHandSideExpressionAddr
+ForInInit							::= ForInIterator S? 'in' S? Expression
+IterationForIn						::= 'for' S? '(' S? ForInInit S? ')' S?  Statement
+
+IterationStatement 					::= IterationWhile |
+									IterationFor |
+									IterationForIn |
+									IterationDo
+
+// 12.9 The return Statement
+ReturnOp							::= ('return' - ('return' IdentifierPart)) WhiteSpace* AssignmentExpression? SC
+ReturnStatement					::= ('return' - ('return' IdentifierPart)) WhiteSpace* AssignmentExpression? SC
+
+// The Break Statement
+BreakOp							::= 'break' - ('break' IdentifierPart)
+BreakStatement					::= S? BreakOp SC
+
+// The Continue Statement
+ContinueOp						::= 'continue' - ('continue' IdentifierPart)
+ContinueStatement					::= S? ContinueOp SC
+
+
+
+// 12.10 The with Statement
+WithStatement						::= 'with' S? '(' S? Expression S? ')' S? Statement
+
+
+// 12.11 The switch Statement
+SwitchExpression					::= ('switch' - ('switch' IdentifierPart)) S? '(' S? Expression S? ')'
+SwitchStatement					::= SwitchExpression S? CaseBlock
+
+CaseBlock							::= '{' S? CaseClauses? S? DefaultClause? S? CaseClauses? S? '}' |
+									'{' S? CaseClauses? S? '}'
+
+
+CaseClauses 						::= (S? CaseClause)+
+CaseExpression						::= ('case' - ('case' IdentifierPart)) S? Expression
+CaseCode							::= S? ':' S? StatementList?
+CaseClause						::= CaseExpression S? CaseCode
+DefaultKeyword						::= 'default' - ('default' IdentifierPart)
+DefaultClause						::= DefaultKeyword S? CaseCode
+
+
+// 13 Function Definition
+FunctionName						::= IdentifierNoEmit
+FunctionDeclaration					::= ('function' - ('function'IdentifierPart)) S? FunctionName S? '(' S? FormalParameterList? S? ')' S? '{' S? FunctionBody? S? '}'
+FunctionExpression					::= ('function' - ('function'IdentifierPart)) S? FunctionName? S? '(' S? FormalParameterList? S? ')' S? '{' S? FunctionBody? S? '}'
+FormalParameterList 				::= FunctionParameter ( S? ',' S? FunctionParameter )*
+FunctionParameter 					::= IdentifierNoEmit
+FunctionBody						::= SourceElements
+FunctionDeclarationStatement			::= ('function' - ('function' IdentifierPart)) S? FunctionName S? '(' S? FormalParameterList? S? ')' SC
+
+// FunctionName					::= IdentifierNoEmit
+// FunctionNameLookupAlloc			::= IdentifierNoEmit
+// FunctionDefinition					::= ('function' - ('function' IdentifierPart)) S? FunctionName S? '(' S?FormalParameterList? S? ')'
+// FunctionDeclaration				::= FunctionDefinition S? '{' S? FunctionBody? S? '}'
+// FunctionExpression					::= ('function' - ('function'IdentifierPart)) S? FunctionName? S? '(' S? FormalParameterList? S? ')' S? '{' S?FunctionBody? S? '}'
+// FunctionParameter 				::= Identifier
+// FormalParameterList 				::= FunctionParameter ( S? ',' S? FunctionParameter )*
+// FunctionDefinitionStatement			::= ('function' - ('function' IdentifierPart)) S? FunctionNameLookupAlloc S? '(' S? FormalParameterList? S? ')' SC
+// FunctionBody						::= SourceElements
+
+
+// 14 Program
+SourceElements 					::= (S? SourceElement)+
+SourceElement 						::= FunctionDeclaration |
+									Statement
+Program							::= SourceElements
+// The root rule, it is anonymous

--- a/rjs/rjsparser.c
+++ b/rjs/rjsparser.c
@@ -54,7 +54,7 @@ rjs_parser_t *rjs_parser_create()
 	rjs_parser_t *parser = (rjs_parser_t *) r_zmalloc(sizeof(*parser));
 
 	parser->dbex = rpa_dbex_create();
-	if (!parser) {
+	if (!parser->dbex) {
 		rjs_parser_destroy(parser);
 		return NULL;
 	}

--- a/rjs/unix/rjsrules.c
+++ b/rjs/unix/rjsrules.c
@@ -1,20 +1,25 @@
 #include "rjs/rjsrules.h"
 
+#ifdef SIMPLE_EBNF
+#define ECMA262_NAME(name) _binary_____________rjs_ecma262_ebnf_##name
+#else
+#define ECMA262_NAME(name) _binary_____________rjs_ecma262_rpa_##name
+#endif
 
-extern char _binary_____________rjs_ecma262_rpa_start[];
-extern char _binary_____________rjs_ecma262_rpa_end[];
-extern unsigned long *_binary_____________rjs_ecma262_rpa_size;
+extern char ECMA262_NAME(start)[];
+extern char ECMA262_NAME(end)[];
+extern unsigned long *ECMA262_NAME(size);
 
 
 const char *rjs_rules_get()
 {
-	const char *rules = _binary_____________rjs_ecma262_rpa_start;
+	const char *rules = ECMA262_NAME(start);
 	return rules;
 }
 
 
 unsigned long rjs_rules_size()
 {
-	unsigned long size = _binary_____________rjs_ecma262_rpa_end - _binary_____________rjs_ecma262_rpa_start;
+	unsigned long size = ECMA262_NAME(end) - ECMA262_NAME(start);
 	return size;
 }

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -176,10 +176,9 @@ static void rpa_production_directive_emitid(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitid", 0, RPA_PRODUCTION_DIRECTIVEEMITID, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitid", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\#');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
@@ -209,8 +208,7 @@ static void rpa_production_directive_emit(rpa_parser_t *pa)
 #ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
@@ -964,16 +962,16 @@ static void rpa_production_aref(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "aref", 0, RPA_PRODUCTION_AREF, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "aref", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-
+#endif
 	rpa_compiler_reference_nan_s(co, "rulename");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-
+#endif
 	rpa_compiler_rule_end(co);
 }
 

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -56,6 +56,13 @@ static void rpa_compiler_branch_nan_s(rpa_compiler_t *co, const char *str)
 	rpa_compiler_branch_end(co);
 }
 
+static inline void rvm_codegen_addins_matcher_range(rpa_compiler_t *co, int rvm_relop, ruword range_start, ruword range_end)
+{
+	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, range_start, range_end));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+}
+
+
 rpa_parser_t *rpa_parser_create()
 {
 	rpa_parser_t *pa;
@@ -420,22 +427,17 @@ static void rpa_production_rulename(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "rulename", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIOPT);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, '0', '9');
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -452,20 +454,15 @@ static void rpa_production_aliasname(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "aliasname", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIOPT);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, '0', '9');
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -860,10 +857,8 @@ static void rpa_production_dec(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "dec", 0, RPA_PRODUCTION_DEC, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "dec", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '1', '9'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_MOP, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_range(co, RVM_BLES, '1', '9');
+	rvm_codegen_addins_matcher_range(co, RVM_BLES, '0', '9');
 
 	rpa_compiler_rule_end(co);
 }
@@ -877,12 +872,9 @@ static void rpa_production_hex(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "hex", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'f'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'F'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, '0', '9');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'f');
+	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'F');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -129,8 +129,7 @@ static void rpa_production_directives(rpa_parser_t *pa)
 	 */
 	rpa_compiler_notexp_begin(co, RPA_MATCH_MULTIOPT);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\r');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\n');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "\r\n");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_notexp_end(co);
@@ -155,9 +154,7 @@ static void rpa_production_bnf(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\r');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\n');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, ';');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "\r\n;");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\0');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -236,8 +233,7 @@ static void rpa_production_directive_abort(rpa_parser_t *pa)
 #ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
@@ -260,8 +256,7 @@ static void rpa_production_directive_emitall(rpa_parser_t *pa)
 #ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
@@ -280,8 +275,7 @@ static void rpa_production_directive_emitnone(rpa_parser_t *pa)
 #ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
@@ -300,8 +294,7 @@ static void rpa_production_directive_noemit(rpa_parser_t *pa)
 #ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
@@ -323,8 +316,7 @@ static void rpa_production_comment(rpa_parser_t *pa)
 #ifndef SIMPLE_EBNF
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
-	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "//");
 #endif // SIMPLE_EBNF
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
@@ -805,15 +797,8 @@ static void rpa_production_alphacls(rpa_parser_t *pa)
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "charrng");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "clschar");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "charrng");
+	rpa_compiler_branch_nan_s(co, "clschar");
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
@@ -870,10 +855,7 @@ static void rpa_production_numcls(rpa_parser_t *pa)
 	rpa_compiler_branch_end(co);
 
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "clsnum");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "clsnum");
 
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -894,15 +876,9 @@ static void rpa_production_cls(rpa_parser_t *pa)
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "numcls");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "numcls");
+	rpa_compiler_branch_nan_s(co, "alphacls");
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "alphacls");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -973,10 +949,8 @@ static void rpa_production_num(rpa_parser_t *pa)
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "dec");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "dec");
+
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -1067,35 +1041,12 @@ static void rpa_production_terminal(rpa_parser_t *pa)
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "cls");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "sqstr");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "dqstr");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "cref");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "aref");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "bracketexp");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "cls");
+	rpa_compiler_branch_nan_s(co, "sqstr");
+	rpa_compiler_branch_nan_s(co, "dqstr");
+	rpa_compiler_branch_nan_s(co, "cref");
+	rpa_compiler_branch_nan_s(co, "aref");
+	rpa_compiler_branch_nan_s(co, "bracketexp");
 
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -1113,20 +1064,9 @@ static void rpa_production_qchar(rpa_parser_t *pa)
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "nsspecialchar");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "escapedchar");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "regexchar");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "nsspecialchar");
+	rpa_compiler_branch_nan_s(co, "escapedchar");
+	rpa_compiler_branch_nan_s(co, "regexchar");
 
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -1154,10 +1094,8 @@ static void rpa_production_qexp(rpa_parser_t *pa)
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_branch_end(co);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "qchar");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "qchar");
+
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -1186,14 +1124,10 @@ static void rpa_production_anchorexp(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "anchorexp", 0);
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "anchorop");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "qexp");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+
+	rpa_compiler_branch_nan_s(co, "anchorop");
+	rpa_compiler_branch_nan_s(co, "qexp");
+
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
@@ -1224,15 +1158,10 @@ static void rpa_production_notexp(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "notexp", 0);
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "notop");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-//	rpa_compiler_reference_nan_s(co, "qexp");
-	rpa_compiler_reference_nan_s(co, "anchorexp");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+
+	rpa_compiler_branch_nan_s(co, "notop");
+	rpa_compiler_branch_nan_s(co, "anchorexp");
+
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
@@ -1350,15 +1279,9 @@ static void rpa_production_minexp(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "minexp", 0);
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "minop");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "minop");
+	rpa_compiler_branch_nan_s(co, "exp");
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "exp");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
 
 	rpa_compiler_rule_end(co);
@@ -1417,15 +1340,9 @@ static void rpa_production_orexp(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "orexp", 0);
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "orop");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "orop");
+	rpa_compiler_branch_nan_s(co, "minexp");
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "minexp");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
 
 	rpa_compiler_rule_end(co);

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -305,7 +305,6 @@ static void rpa_production_directive_noemit(rpa_parser_t *pa)
 	rpa_compiler_rule_end(co);
 }
 
-
 static void rpa_production_comment(rpa_parser_t *pa)
 {
 	rpa_compiler_t *co = pa->co;
@@ -1002,6 +1001,11 @@ static void rpa_production_cref(rpa_parser_t *pa)
 }
 
 
+#if DUMMY_FOR_COMMENTS
+mcstart ::= '/*'
+mcend ::= '*/'
+mc ::= <mcstart> (. - <mcend>)* <mcend>
+#endif
 static void rpa_production_multiline_comment(rpa_parser_t *pa)
 {
 	rpa_compiler_t *co = pa->co;

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -23,6 +23,7 @@
 #include "rlib/rstring.h"
 #include "rpa/rpaparser.h"
 #include "rpa/rpastatpriv.h"
+#include <string.h>
 
 static int rpa_parser_init(rpa_parser_t *pa);
 
@@ -34,6 +35,25 @@ static inline void rvm_codegen_index_addrelocins_reloc_branch(rpa_compiler_t *co
 static inline void rvm_codegen_addins_matcher(rpa_compiler_t *co, ruword matcher, ruword ch)
 {
 	rvm_codegen_addins(co->cg, rvm_asm(matcher, DA, XX, XX, ch));
+}
+
+static inline void rvm_codegen_addins_matcher_nan_ch(rpa_compiler_t *co, int rvm_relop, ruword ch)
+{
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ch);
+	rvm_codegen_index_addrelocins_reloc_branch(co, rvm_relop);
+}
+
+static inline void rvm_codegen_addins_matcher_nan_str(rpa_compiler_t *co, int rvm_relop, const char *str)
+{
+	for(int i=0, len=strlen(str); i< len; ++i) rvm_codegen_addins_matcher_nan_ch(co, rvm_relop, str[i]);
+}
+
+static void rpa_compiler_branch_nan_s(rpa_compiler_t *co, const char *str)
+{
+	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
+	rpa_compiler_reference_nan_s(co, str);
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rpa_compiler_branch_end(co);
 }
 
 rpa_parser_t *rpa_parser_create()
@@ -94,36 +114,13 @@ static void rpa_production_directives(rpa_parser_t *pa)
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "emit");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
+	rpa_compiler_branch_nan_s(co, "emit");
+	rpa_compiler_branch_nan_s(co, "noemit");
+	rpa_compiler_branch_nan_s(co, "emitall");
+	rpa_compiler_branch_nan_s(co, "emitnone");
+	rpa_compiler_branch_nan_s(co, "abort");
+	rpa_compiler_branch_nan_s(co, "emitid");
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "noemit");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "emitall");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "emitnone");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "abort");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "emitid");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -132,10 +129,8 @@ static void rpa_production_directives(rpa_parser_t *pa)
 	 */
 	rpa_compiler_notexp_begin(co, RPA_MATCH_MULTIOPT);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\r');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\n');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_notexp_end(co);
@@ -153,51 +148,23 @@ static void rpa_production_bnf(rpa_parser_t *pa)
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "directives");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "comment");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "multilinecomment");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
+	rpa_compiler_branch_nan_s(co, "space");
+	rpa_compiler_branch_nan_s(co, "directives");
+	rpa_compiler_branch_nan_s(co, "comment");
+	rpa_compiler_branch_nan_s(co, "multilinecomment");
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ';');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\r');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\n');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, ';');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\0');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "namedrule");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
-	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rpa_compiler_reference_nan_s(co, "anonymousrule");
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rpa_compiler_branch_end(co);
-
+	rpa_compiler_branch_nan_s(co, "namedrule");
+	rpa_compiler_branch_nan_s(co, "anonymousrule");
 
 	rpa_compiler_altexp_end(co);
 
@@ -212,30 +179,15 @@ static void rpa_production_directive_emitid(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitid", 0, RPA_PRODUCTION_DIRECTIVEEMITID, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitid", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'd');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "emitid");
 	rpa_compiler_reference_nan_s(co, "space");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
@@ -258,26 +210,15 @@ static void rpa_production_directive_emit(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emit", 0, RPA_PRODUCTION_DIRECTIVEEMIT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emit", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "emit");
 	rpa_compiler_reference_nan_s(co, "space");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
@@ -293,28 +234,15 @@ static void rpa_production_directive_abort(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "abort", 0, RPA_PRODUCTION_DIRECTIVEABORT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "abort", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'a');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'b');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'o');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "abort");
 	rpa_compiler_reference_nan_s(co, "space");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
@@ -330,32 +258,15 @@ static void rpa_production_directive_emitall(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitall", 0, RPA_PRODUCTION_DIRECTIVEEMITALL, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitall", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'a');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'l');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'l');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "emitall");
 	rpa_compiler_rule_end(co);
 }
 
@@ -367,34 +278,15 @@ static void rpa_production_directive_emitnone(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitnone", 0, RPA_PRODUCTION_DIRECTIVEEMITNONE, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitnone", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'o');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "emitnone");
 	rpa_compiler_rule_end(co);
 }
 
@@ -406,30 +298,15 @@ static void rpa_production_directive_noemit(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "noemit", 0, RPA_PRODUCTION_DIRECTIVENOEMIT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "noemit", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '!');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'o');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "noemit");
 	rpa_compiler_reference_nan_s(co, "space");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
@@ -444,13 +321,10 @@ static void rpa_production_comment(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "comment", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 #else
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '/');
 #endif // SIMPLE_EBNF
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
@@ -549,12 +423,7 @@ static void rpa_production_space(rpa_parser_t *pa)
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "\\\r\n");
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_altexp_end(co);
@@ -638,11 +507,7 @@ static void rpa_production_assign(rpa_parser_t *pa)
 
 	rpa_compiler_reference_opt_s(co, "space");
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '=');
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "::=");
 
 	rpa_compiler_reference_mop_s(co, "space");
 
@@ -660,54 +525,11 @@ static void rpa_production_regexchar(rpa_parser_t *pa)
 
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '~');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '^');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '|');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '&');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '+');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '?');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '(');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ')');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, " ~#^-|&+*?\"\'()[]"
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '.');
+		"<>."
 #endif
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ';');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+		";\t\r\n");
 	rpa_compiler_reference_nan_s(co, "char");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -769,12 +591,7 @@ static void rpa_production_specialchar(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "specialchar", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "rnt");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -808,12 +625,7 @@ static void rpa_production_specialclschar(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "specialclschar", 0, RPA_PRODUCTION_SPECIALCLSCHAR, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "specialclschar", 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "rnt");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
@@ -821,32 +633,18 @@ static void rpa_production_specialclschar(rpa_parser_t *pa)
 
 
 /*
- * None of the " #\\-[]\t\n\r\0"
+ * None of the " #\\-[]\t\r\n\0"
  */
 static void rpa_production_clschars(rpa_parser_t *pa)
 {
 	rpa_compiler_t *co = pa->co;
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	const char clschars[] = " #\\-[]\t\r\n\0";
+	for(int idx=0; idx < (sizeof(clschars)/sizeof(char)); ++idx)
+	{
+		rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, clschars[idx]);
+		rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	}
 }
 
 
@@ -907,12 +705,7 @@ static void rpa_production_occurence(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "occurence", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '?');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '+');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "?+*");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -1167,7 +960,7 @@ static void rpa_production_num(rpa_parser_t *pa)
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '0'));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '0');
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'x');
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
@@ -1598,14 +1391,14 @@ static void rpa_production_orop(rpa_parser_t *pa)
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\r'));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\n'));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\r');
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\n');
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '|');
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\r'));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\n'));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\r');
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\n');
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_nan_s(co, "altbranch");

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -56,10 +56,10 @@ static void rpa_compiler_branch_nan_s(rpa_compiler_t *co, const char *str)
 	rpa_compiler_branch_end(co);
 }
 
-static inline void rvm_codegen_addins_matcher_range(rpa_compiler_t *co, int rvm_relop, ruword range_start, ruword range_end)
+static inline void rvm_codegen_addins_matcher_range(rpa_compiler_t *co, ruword matcher, int rvm_relop, ruword range_start, ruword range_end)
 {
-	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, range_start, range_end));
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins(co->cg, rvm_asm2(matcher, DA, XX, XX, range_start, range_end));
+	rvm_codegen_index_addrelocins_reloc_branch(co, rvm_relop);
 }
 
 
@@ -157,8 +157,9 @@ static void rpa_production_bnf(rpa_parser_t *pa)
 	rpa_compiler_branch_nan_s(co, "space");
 	rpa_compiler_branch_nan_s(co, "directives");
 	rpa_compiler_branch_nan_s(co, "comment");
+#ifdef SIMPLE_EBNF
 	rpa_compiler_branch_nan_s(co, "multilinecomment");
-
+#endif
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
 	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "\r\n;");
@@ -427,17 +428,17 @@ static void rpa_production_rulename(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "rulename", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'A', 'Z');
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIOPT);
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, '0', '9');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'A', 'Z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, '0', '9');
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -454,15 +455,15 @@ static void rpa_production_aliasname(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "aliasname", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'A', 'Z');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIOPT);
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'z');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'Z');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, '0', '9');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'a', 'z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'A', 'Z');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, '0', '9');
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -480,7 +481,8 @@ static void rpa_production_assign(rpa_parser_t *pa)
 
 	rpa_compiler_reference_opt_s(co, "space");
 
-	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "::=");
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "::");
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '=');
 
 	rpa_compiler_reference_mop_s(co, "space");
 
@@ -497,11 +499,11 @@ static void rpa_production_regexchar(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "regexchar", 0);
 
 	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\0');
-	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, " ~#^-|&+*?\"\'()[]"
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, " ~#^-|&+*?\"'()[]"
 #ifndef SIMPLE_EBNF
-		"<>."
+		"<>"
 #endif
-		";\t\r\n");
+		".;\t\r\n");
 	rpa_compiler_reference_nan_s(co, "char");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -857,8 +859,8 @@ static void rpa_production_dec(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "dec", 0, RPA_PRODUCTION_DEC, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "dec", 0);
 
-	rvm_codegen_addins_matcher_range(co, RVM_BLES, '1', '9');
-	rvm_codegen_addins_matcher_range(co, RVM_BLES, '0', '9');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BLES, '1', '9');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_MOP, RVM_BLES, '0', '9');
 
 	rpa_compiler_rule_end(co);
 }
@@ -872,9 +874,9 @@ static void rpa_production_hex(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "hex", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, '0', '9');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'a', 'f');
-	rvm_codegen_addins_matcher_range(co, RVM_BGRE, 'A', 'F');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, '0', '9');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'a', 'f');
+	rvm_codegen_addins_matcher_range(co, RPA_MATCHRNG_NAN, RVM_BGRE, 'A', 'F');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -949,6 +951,7 @@ static void rpa_production_cref(rpa_parser_t *pa)
 }
 
 
+#ifdef SIMPLE_EBNF
 #if DUMMY_FOR_COMMENTS
 mcstart ::= '/*'
 mcend ::= '*/'
@@ -975,7 +978,7 @@ static void rpa_production_multiline_comment(rpa_parser_t *pa)
 
 	rpa_compiler_rule_end(co);
 }
-
+#endif
 
 
 static void rpa_production_terminal(rpa_parser_t *pa)
@@ -1361,7 +1364,9 @@ static int rpa_parser_init(rpa_parser_t *pa)
 	rpa_production_namedrule(pa);
 	rpa_production_anonymousrule(pa);
 	rpa_production_comment(pa);
+#ifdef SIMPLE_EBNF
 	rpa_production_multiline_comment(pa);
+#endif
 	rpa_production_bnf(pa);
 
 	if (rvm_codegen_relocate(co->cg, &err) < 0) {

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -26,6 +26,15 @@
 
 static int rpa_parser_init(rpa_parser_t *pa);
 
+static inline void rvm_codegen_index_addrelocins_reloc_branch(rpa_compiler_t *co, int rvm_relop)
+{
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(rvm_relop, DA, XX, XX, 0));
+}
+
+static inline void rvm_codegen_addins_matcher(rpa_compiler_t *co, ruword matcher, ruword ch)
+{
+	rvm_codegen_addins(co->cg, rvm_asm(matcher, DA, XX, XX, ch));
+}
 
 rpa_parser_t *rpa_parser_create()
 {
@@ -87,48 +96,48 @@ static void rpa_production_directives(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "emit");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "noemit");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "emitall");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "emitnone");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "abort");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "emitid");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	/*
 	 * Skip any junk we might have up to the end of the line
 	 */
 	rpa_compiler_notexp_begin(co, RPA_MATCH_MULTIOPT);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_notexp_end(co);
 
 	rpa_compiler_rule_end(co);
@@ -146,41 +155,47 @@ static void rpa_production_bnf(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "directives");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "comment");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
+	rpa_compiler_reference_nan_s(co, "multilinecomment");
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rpa_compiler_branch_end(co);
+
+
+	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ';'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\0'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ';');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "namedrule");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "anonymousrule");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 
@@ -197,40 +212,40 @@ static void rpa_production_directive_emitid(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitid", 0, RPA_PRODUCTION_DIRECTIVEEMITID, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitid", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'e'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'm'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'i'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'i'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'd'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'd');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "aliasname");
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_nan_s(co, "dec");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -243,28 +258,28 @@ static void rpa_production_directive_emit(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emit", 0, RPA_PRODUCTION_DIRECTIVEEMIT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emit", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'e'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'm'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'i'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
 
 	rpa_compiler_rule_end(co);
@@ -278,30 +293,30 @@ static void rpa_production_directive_abort(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "abort", 0, RPA_PRODUCTION_DIRECTIVEABORT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "abort", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'a'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'b'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'o'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'a');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'b');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'o');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
 
 	rpa_compiler_rule_end(co);
@@ -315,32 +330,32 @@ static void rpa_production_directive_emitall(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitall", 0, RPA_PRODUCTION_DIRECTIVEEMITALL, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitall", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'e'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'm'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'i'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'a'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'l'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'l'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'a');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'l');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'l');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -352,34 +367,34 @@ static void rpa_production_directive_emitnone(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "emitnone", 0, RPA_PRODUCTION_DIRECTIVEEMITNONE, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitnone", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'e'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'm'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'i'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'o'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'e'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'o');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -391,32 +406,32 @@ static void rpa_production_directive_noemit(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "noemit", 0, RPA_PRODUCTION_DIRECTIVENOEMIT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "noemit", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '!');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'o'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'e'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'm'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'i'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'o');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'e');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'm');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'i');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "space");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "rulename");
 
 	rpa_compiler_rule_end(co);
@@ -429,29 +444,29 @@ static void rpa_production_comment(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "comment", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #else
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif // SIMPLE_EBNF
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\0'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHSPCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHSPCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
 
 	rpa_compiler_rule_end(co);
@@ -468,13 +483,13 @@ static void rpa_production_namedrule(rpa_parser_t *pa)
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_nan_s(co, "rulename");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_nan_s(co, "assign");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_mul_s(co, "orexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -490,7 +505,7 @@ static void rpa_production_anonymousrule(rpa_parser_t *pa)
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_mul_s(co, "orexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -503,12 +518,12 @@ static void rpa_production_space(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "space", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ' '));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\t'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -525,21 +540,21 @@ static void rpa_production_space(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ' '));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\t'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\\'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_altexp_end(co);
@@ -558,26 +573,26 @@ static void rpa_production_rulename(rpa_parser_t *pa)
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '_'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '_');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIOPT);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '_'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '_');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -592,23 +607,23 @@ static void rpa_production_aliasname(rpa_parser_t *pa)
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIOPT);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '_'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '_');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -623,11 +638,11 @@ static void rpa_production_assign(rpa_parser_t *pa)
 
 	rpa_compiler_reference_opt_s(co, "space");
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ':'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ':'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '='));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '=');
 
 	rpa_compiler_reference_mop_s(co, "space");
 
@@ -643,58 +658,58 @@ static void rpa_production_regexchar(rpa_parser_t *pa)
 	rpa_compiler_t *co = pa->co;
 	rpa_compiler_rule_begin_s(co, "regexchar", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\0'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ' '));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '~'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '^'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '-'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '|'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '&'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '+'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '*'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '?'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '"'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\''));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '('));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ')'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '['));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ']'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '~');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '^');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '|');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '&');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '+');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '?');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '(');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ')');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '<'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '>'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '.'));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '.');
 #endif
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ';'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\t'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ';');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_reference_nan_s(co, "char");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -706,8 +721,8 @@ static void rpa_production_char(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "char", 0, RPA_PRODUCTION_CHAR, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "char", 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHSPCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHSPCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -717,19 +732,19 @@ static void rpa_production_escapedchar(rpa_parser_t *pa)
 	rpa_compiler_t *co = pa->co;
 
 	rpa_compiler_rule_begin_s(co, "escapedchar", 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\\'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "specialchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "char");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -740,8 +755,8 @@ static void rpa_production_escapedclschar(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "escapedclschar", 0, RPA_PRODUCTION_CLSCHAR, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "escapedclschar", 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHSPCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHSPCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -754,14 +769,14 @@ static void rpa_production_specialchar(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "specialchar", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -775,12 +790,12 @@ static void rpa_production_nsspecialchar(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "nsspecialchar", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-//	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '~'));
-//	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+//	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '~');
+//	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -793,14 +808,14 @@ static void rpa_production_specialclschar(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "specialclschar", 0, RPA_PRODUCTION_SPECIALCLSCHAR, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "specialclschar", 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 't'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 't');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -812,26 +827,26 @@ static void rpa_production_clschars(rpa_parser_t *pa)
 {
 	rpa_compiler_t *co = pa->co;
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ' '));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\\'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '-'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '['));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ']'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\t'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\r'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\n'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\0'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 }
 
 
@@ -843,8 +858,8 @@ static void rpa_production_clschar(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "clschar", 0);
 
 	rpa_production_clschars(pa);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHSPCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHSPCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -859,9 +874,9 @@ static void rpa_production_beginchar(rpa_parser_t *pa)
 //	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
 	rpa_production_clschars(pa);
 //	rpa_compiler_class_end(co);
-//	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHSPCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+//	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHSPCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -877,9 +892,9 @@ static void rpa_production_endchar(rpa_parser_t *pa)
 //	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
 	rpa_production_clschars(pa);
 //	rpa_compiler_class_end(co);
-//	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHSPCHR_NAN, DA, XX, XX, '.'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+//	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHSPCHR_NAN, '.');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -892,14 +907,14 @@ static void rpa_production_occurence(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "occurence", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '?'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '+'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '*'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '?');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '+');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -912,11 +927,11 @@ static void rpa_production_charrng(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "charrng", 0, RPA_PRODUCTION_CHARRNG, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "charrng", 0);
 	rpa_compiler_reference_nan_s(co, "beginchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '-'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "endchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -929,11 +944,11 @@ static void rpa_production_numrng(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "numrng", 0);
 
 	rpa_compiler_reference_nan_s(co, "num");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '-'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "num");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -945,18 +960,18 @@ static void rpa_production_sqstr(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "sqstr", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\''));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\''));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_reference_nan_s(co, "char");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\''));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -968,19 +983,19 @@ static void rpa_production_dqstr(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "dqstr", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '"'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '"'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_reference_nan_s(co, "char");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '"'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -992,40 +1007,40 @@ static void rpa_production_alphacls(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "alphacls", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '['));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "charrng");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "clschar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\\'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "specialclschar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '\\'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_nan_s(co, "escapedclschar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ']'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1039,7 +1054,7 @@ static void rpa_production_clsnum(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "clsnum", 0);
 
 	rpa_compiler_reference_nan_s(co, "num");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1051,8 +1066,8 @@ static void rpa_production_numcls(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "numcls", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '['));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
@@ -1064,14 +1079,14 @@ static void rpa_production_numcls(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "clsnum");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ']'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1088,15 +1103,15 @@ static void rpa_production_cls(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "numcls");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "alphacls");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1110,9 +1125,9 @@ static void rpa_production_dec(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "dec", 0);
 
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '1', '9'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_MOP, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1127,13 +1142,13 @@ static void rpa_production_hex(rpa_parser_t *pa)
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'a', 'f'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'F'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 
 	rpa_compiler_rule_end(co);
@@ -1146,31 +1161,31 @@ static void rpa_production_num(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "num", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '0'));
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'x'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, 'X'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'x');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'X');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_nan_s(co, "hex");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "dec");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1183,14 +1198,14 @@ static void rpa_production_aref(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "aref", 0, RPA_PRODUCTION_AREF, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "aref", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '<'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_nan_s(co, "rulename");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '>'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1203,23 +1218,52 @@ static void rpa_production_cref(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "cref", 0, RPA_PRODUCTION_CREF, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "cref", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '<'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ':'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif
 	rpa_compiler_reference_nan_s(co, "rulename");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ':'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '>'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #endif
 	rpa_compiler_rule_end(co);
 }
+
+
+static void rpa_production_multiline_comment(rpa_parser_t *pa)
+{
+	rpa_compiler_t *co = pa->co;
+
+	rpa_compiler_rule_begin_s(co, "multilinecomment", 0);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+
+	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
+	rpa_compiler_notexp_begin(co, RPA_MATCH_NONE);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rpa_compiler_notexp_end(co);
+	rpa_compiler_exp_end(co);
+
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+
+	rpa_compiler_rule_end(co);
+}
+
 
 
 static void rpa_production_terminal(rpa_parser_t *pa)
@@ -1232,36 +1276,36 @@ static void rpa_production_terminal(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "cls");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "sqstr");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "dqstr");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "cref");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "aref");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "bracketexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 
 	rpa_compiler_rule_end(co);
@@ -1278,21 +1322,21 @@ static void rpa_production_qchar(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "nsspecialchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "escapedchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "regexchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_opt_s(co, "occurence");
 	rpa_compiler_reference_opt_s(co, "space");
@@ -1310,19 +1354,19 @@ static void rpa_production_qexp(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "terminal");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_opt_s(co, "occurence");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "qchar");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1334,11 +1378,11 @@ static void rpa_production_anchorop(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "anchorop", 0, RPA_PRODUCTION_ANCHOROP, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "anchorop", 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '~'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '~');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_nan_s(co, "qexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -1351,14 +1395,14 @@ static void rpa_production_anchorexp(rpa_parser_t *pa)
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "anchorop");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "qexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_rule_end(co);
 }
@@ -1370,12 +1414,12 @@ static void rpa_production_notop(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "notop", 0, RPA_PRODUCTION_NOTOP, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "notop", 0);
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '^'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '^');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_nan_s(co, "anchorexp");
 
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1389,15 +1433,15 @@ static void rpa_production_notexp(rpa_parser_t *pa)
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "notop");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 //	rpa_compiler_reference_nan_s(co, "qexp");
 	rpa_compiler_reference_nan_s(co, "anchorexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_rule_end(co);
 }
@@ -1410,7 +1454,7 @@ static void rpa_production_exp(rpa_parser_t *pa)
 //	rpa_compiler_rulepref_set_s(co, "exp", 0, RPA_PRODUCTION_EXP);
 	rpa_compiler_rule_begin_s(co, "exp", 0);
 	rpa_compiler_reference_mul_s(co, "notexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
 }
 
@@ -1422,18 +1466,18 @@ static void rpa_production_bracketexp(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "bracketexp", 0, RPA_PRODUCTION_BRACKETEXP, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "bracketexp", 0);
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '('));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '(');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_nan_s(co, "orexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_opt_s(co, "space");
 
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ')'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ')');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1448,7 +1492,7 @@ static void rpa_production_negbranch(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "negbranch", 0);
 
 	rpa_compiler_reference_nan_s(co, "exp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1463,12 +1507,12 @@ static void rpa_production_norop(rpa_parser_t *pa)
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '-'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_mul_s(co, "negbranch");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
 
 	rpa_compiler_rule_end(co);
@@ -1483,7 +1527,7 @@ static void rpa_production_reqop(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "reqop", 0);
 
 	rpa_compiler_reference_nan_s(co, "exp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1497,10 +1541,10 @@ static void rpa_production_minop(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "minop", 0);
 
 	rpa_compiler_reference_nan_s(co, "reqop");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_reference_nan_s(co, "norop");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1515,12 +1559,12 @@ static void rpa_production_minexp(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "minop");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "exp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
 
@@ -1536,7 +1580,7 @@ static void rpa_production_altbranch(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "altbranch", 0);
 
 	rpa_compiler_reference_nan_s(co, "minexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1550,24 +1594,24 @@ static void rpa_production_orop(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "orop", 0);
 
 	rpa_compiler_reference_nan_s(co, "altbranch");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\r'));
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\n'));
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '|'));
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '|');
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\r'));
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_OPT, DA, XX, XX, '\n'));
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_nan_s(co, "altbranch");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
 	rpa_compiler_rule_end(co);
 }
@@ -1582,12 +1626,12 @@ static void rpa_production_orexp(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "orop");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "minexp");
-	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 	rpa_compiler_altexp_end(co);
 
@@ -1668,6 +1712,7 @@ static int rpa_parser_init(rpa_parser_t *pa)
 	rpa_production_namedrule(pa);
 	rpa_production_anonymousrule(pa);
 	rpa_production_comment(pa);
+	rpa_production_multiline_comment(pa);
 	rpa_production_bnf(pa);
 
 	if (rvm_codegen_relocate(co->cg, &err) < 0) {

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -196,9 +196,15 @@ static void rpa_production_directive_emitid(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "emitid", 0, RPA_PRODUCTION_DIRECTIVEEMITID, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitid", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
@@ -236,9 +242,15 @@ static void rpa_production_directive_emit(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "emit", 0, RPA_PRODUCTION_DIRECTIVEEMIT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emit", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
@@ -265,9 +277,15 @@ static void rpa_production_directive_abort(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "abort", 0, RPA_PRODUCTION_DIRECTIVEABORT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "abort", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
@@ -296,9 +314,15 @@ static void rpa_production_directive_emitall(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "emitall", 0, RPA_PRODUCTION_DIRECTIVEEMITALL, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitall", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
@@ -327,9 +351,15 @@ static void rpa_production_directive_emitnone(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "emitnone", 0, RPA_PRODUCTION_DIRECTIVEEMITNONE, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "emitnone", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
@@ -360,9 +390,15 @@ static void rpa_production_directive_noemit(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "noemit", 0, RPA_PRODUCTION_DIRECTIVENOEMIT, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "noemit", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '!'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
@@ -392,9 +428,15 @@ static void rpa_production_comment(rpa_parser_t *pa)
 	rpa_compiler_t *co = pa->co;
 
 	rpa_compiler_rule_begin_s(co, "comment", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '#'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#else
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '/'));
+	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
+#endif // SIMPLE_EBNF
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
@@ -635,11 +677,13 @@ static void rpa_production_regexchar(rpa_parser_t *pa)
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ']'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '<'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '>'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '.'));
+#endif
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ';'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BGRE, DA, XX, XX, 0));
@@ -1158,22 +1202,22 @@ static void rpa_production_cref(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "cref", 0, RPA_PRODUCTION_CREF, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "cref", 0);
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '<'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
 
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ':'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-
+#endif
 	rpa_compiler_reference_nan_s(co, "rulename");
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-
+#ifndef SIMPLE_EBNF
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, ':'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
 
 	rvm_codegen_addins(co->cg, rvm_asm(RPA_MATCHCHR_NAN, DA, XX, XX, '>'));
 	rvm_codegen_index_addrelocins(co->cg, RVM_RELOC_BRANCH, RPA_COMPILER_CURRENTEXP(co)->endidx, rvm_asm(RVM_BLES, DA, XX, XX, 0));
-
+#endif
 	rpa_compiler_rule_end(co);
 }
 

--- a/rpa/rpaparser.c
+++ b/rpa/rpaparser.c
@@ -319,12 +319,8 @@ static void rpa_production_comment(rpa_parser_t *pa)
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\r');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\n');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "\r\n");
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\0');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
@@ -381,10 +377,7 @@ static void rpa_production_space(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "space", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_MULTIPLE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, " \t");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -403,10 +396,7 @@ static void rpa_production_space(rpa_parser_t *pa)
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ' ');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\t');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, " \t");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
@@ -434,8 +424,7 @@ static void rpa_production_rulename(rpa_parser_t *pa)
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, 'A', 'Z'));
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '_');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -447,8 +436,7 @@ static void rpa_production_rulename(rpa_parser_t *pa)
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '_');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -478,8 +466,7 @@ static void rpa_production_aliasname(rpa_parser_t *pa)
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rvm_codegen_addins(co->cg, rvm_asm2(RPA_MATCHRNG_NAN, DA, XX, XX, '0', '9'));
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '_');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '_');
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -512,8 +499,7 @@ static void rpa_production_regexchar(rpa_parser_t *pa)
 	rpa_compiler_t *co = pa->co;
 	rpa_compiler_rule_begin_s(co, "regexchar", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\0');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\0');
 	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, " ~#^-|&+*?\"\'()[]"
 #ifndef SIMPLE_EBNF
 		"<>."
@@ -543,8 +529,7 @@ static void rpa_production_escapedchar(rpa_parser_t *pa)
 	rpa_compiler_t *co = pa->co;
 
 	rpa_compiler_rule_begin_s(co, "escapedchar", 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\\');
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rpa_compiler_reference_nan_s(co, "specialchar");
@@ -596,8 +581,7 @@ static void rpa_production_nsspecialchar(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "nsspecialchar", 0);
 
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '.');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '.');
 //	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '~');
 //	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
 	rpa_compiler_class_end(co);
@@ -710,8 +694,7 @@ static void rpa_production_charrng(rpa_parser_t *pa)
 	rpa_compiler_rule_begin_s(co, "charrng", 0);
 	rpa_compiler_reference_nan_s(co, "beginchar");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '-');
 	rpa_compiler_reference_nan_s(co, "endchar");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_rule_end(co);
@@ -727,8 +710,7 @@ static void rpa_production_numrng(rpa_parser_t *pa)
 
 	rpa_compiler_reference_nan_s(co, "num");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '-');
 	rpa_compiler_reference_nan_s(co, "num");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -742,18 +724,15 @@ static void rpa_production_sqstr(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "sqstr", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\'');
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '\'');
 	rpa_compiler_reference_nan_s(co, "char");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\'');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\'');
 
 	rpa_compiler_rule_end(co);
 }
@@ -765,19 +744,16 @@ static void rpa_production_dqstr(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "dqstr", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '"');
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BGRE, '"');
 	rpa_compiler_reference_nan_s(co, "char");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_exp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '"');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '"');
 
 	rpa_compiler_rule_end(co);
 }
@@ -789,8 +765,7 @@ static void rpa_production_alphacls(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "alphacls", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '[');
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
@@ -798,15 +773,13 @@ static void rpa_production_alphacls(rpa_parser_t *pa)
 	rpa_compiler_branch_nan_s(co, "clschar");
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\\');
 	rpa_compiler_reference_nan_s(co, "specialclschar");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '\\');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '\\');
 	rpa_compiler_reference_nan_s(co, "escapedclschar");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 	rpa_compiler_branch_end(co);
@@ -814,8 +787,7 @@ static void rpa_production_alphacls(rpa_parser_t *pa)
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, ']');
 
 	rpa_compiler_rule_end(co);
 }
@@ -841,8 +813,7 @@ static void rpa_production_numcls(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "numcls", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '[');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '[');
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_MULTIPLE, 0);
 
@@ -857,8 +828,7 @@ static void rpa_production_numcls(rpa_parser_t *pa)
 	rpa_compiler_altexp_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ']');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, ']');
 
 	rpa_compiler_rule_end(co);
 }
@@ -927,18 +897,14 @@ static void rpa_production_num(rpa_parser_t *pa)
 
 	rpa_compiler_rule_begin_s(co, "num", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '#');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '#');
 
 	rpa_compiler_altexp_begin(co, RPA_MATCH_NONE, 0);
 
 	rpa_compiler_branch_begin(co, RPA_MATCH_NONE, 0);
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '0');
 	rpa_compiler_class_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'x');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, 'X');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BGRE);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BGRE, "xX");
 	rpa_compiler_class_end(co);
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
@@ -962,14 +928,12 @@ static void rpa_production_aref(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "aref", 0, RPA_PRODUCTION_AREF, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "aref", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '<');
 #endif
 	rpa_compiler_reference_nan_s(co, "rulename");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '>');
 #endif
 	rpa_compiler_rule_end(co);
 }
@@ -982,20 +946,12 @@ static void rpa_production_cref(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "cref", 0, RPA_PRODUCTION_CREF, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "cref", 0);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '<');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "<:");
 #endif
 	rpa_compiler_reference_nan_s(co, "rulename");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 #ifndef SIMPLE_EBNF
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ':');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '>');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, ":>");
 #endif
 	rpa_compiler_rule_end(co);
 }
@@ -1011,24 +967,19 @@ static void rpa_production_multiline_comment(rpa_parser_t *pa)
 	rpa_compiler_t *co = pa->co;
 
 	rpa_compiler_rule_begin_s(co, "multilinecomment", 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
 
+	//mcstart ::= '/*'
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "/*");
+
+	//(. - <mcend>)*
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIOPT, 0);
 	rpa_compiler_notexp_begin(co, RPA_MATCH_NONE);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "*/");
 	rpa_compiler_notexp_end(co);
 	rpa_compiler_exp_end(co);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '*');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '/');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	//mcend ::= '*/'
+	rvm_codegen_addins_matcher_nan_str(co, RVM_BLES, "*/");
 
 	rpa_compiler_rule_end(co);
 }
@@ -1111,8 +1062,7 @@ static void rpa_production_anchorop(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "anchorop", 0, RPA_PRODUCTION_ANCHOROP, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "anchorop", 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '~');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '~');
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_nan_s(co, "qexp");
 	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
@@ -1143,8 +1093,7 @@ static void rpa_production_notop(rpa_parser_t *pa)
 
 	rpa_compiler_rulepref_set_s(co, "notop", 0, RPA_PRODUCTION_NOTOP, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "notop", 0);
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '^');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '^');
 	rpa_compiler_reference_opt_s(co, "space");
 	rpa_compiler_reference_nan_s(co, "anchorexp");
 
@@ -1190,8 +1139,7 @@ static void rpa_production_bracketexp(rpa_parser_t *pa)
 	rpa_compiler_rulepref_set_s(co, "bracketexp", 0, RPA_PRODUCTION_BRACKETEXP, RPA_RFLAG_EMITRECORD);
 	rpa_compiler_rule_begin_s(co, "bracketexp", 0);
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '(');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '(');
 
 	rpa_compiler_reference_opt_s(co, "space");
 
@@ -1200,8 +1148,7 @@ static void rpa_production_bracketexp(rpa_parser_t *pa)
 
 	rpa_compiler_reference_opt_s(co, "space");
 
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, ')');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, ')');
 
 	rpa_compiler_rule_end(co);
 }
@@ -1231,8 +1178,7 @@ static void rpa_production_norop(rpa_parser_t *pa)
 
 	rpa_compiler_exp_begin(co, RPA_MATCH_MULTIPLE, 0);
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '-');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '-');
 	rpa_compiler_reference_opt_s(co, "space");
 
 	rpa_compiler_reference_mul_s(co, "negbranch");
@@ -1319,8 +1265,7 @@ static void rpa_production_orop(rpa_parser_t *pa)
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\r');
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\n');
 	rpa_compiler_reference_opt_s(co, "space");
-	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_NAN, '|');
-	rvm_codegen_index_addrelocins_reloc_branch(co, RVM_BLES);
+	rvm_codegen_addins_matcher_nan_ch(co, RVM_BLES, '|');
 	rpa_compiler_reference_opt_s(co, "space");
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\r');
 	rvm_codegen_addins_matcher(co, RPA_MATCHCHR_OPT, '\n');

--- a/rpagrep/unix/main.c
+++ b/rpagrep/unix/main.c
@@ -69,7 +69,7 @@ int usage(int argc, const char *argv[])
 		fprintf(stderr, "\t    --exec-debug         Execute in debug mode.\n");
 		fprintf(stderr, "\t    --no-cache           Disable execution cache.\n");
 		fprintf(stderr, "\t    --no-bitmap          Disable expression bitmap use.\n");
-		
+
 		return 0;
 }
 
@@ -147,7 +147,7 @@ int main(int argc, const char *argv[])
 				if (ret < 0)
 					goto error;
 			}
-			
+
 		}
 	}
 
@@ -230,7 +230,7 @@ int main(int argc, const char *argv[])
 				if (argv[i]) {
 					rpa_buffer_t pattern;
 					pattern.s = (char*)argv[i];
-					pattern.size = strlen(argv[i]);					
+					pattern.size = strlen(argv[i]);
 					rpa_grep_dump_pattern_tree(pGrep, &pattern);
 					goto end;
 				}
@@ -255,7 +255,7 @@ int main(int argc, const char *argv[])
 			devnull = fopen("/dev/null", "w");
 			stdout = devnull;
 		}
-		
+
 	}
 
 
@@ -279,7 +279,7 @@ int main(int argc, const char *argv[])
 		} else if (argv[i][1] == 'e' || argv[i][1] == 'f' || argv[i][1] == 'c' || argv[i][1] == 'C'){
 			++i;
 		}
-		
+
 	}
 
 	if (!scanned) {
@@ -313,8 +313,9 @@ end:
 
 	if (devnull)
 		fclose(devnull);
+	i = pGrep->ret;
 	rpa_grep_destroy(pGrep);
-	return pGrep->ret;
+	return i;
 
 error:
 	if (devnull)


### PR DESCRIPTION
…https://www.bottlecaps.de/rr/ui no need of "<> <::>" wrapping production names and "// //!" for line comments and directives.

But I also want to have multiple line comments and with the existing information/documentation I'm not sure how to add it to "rpa_production_comment", can you give a help with this ?

When SIMPLE_EBNF id defined:

- <><::> is not used to wrap production names

- "//" is the single line comment

- "//!" is the way to emit directives

- "/* ... */" multi line comment is not yet implemented, need your help

Thank you for your great work ! 
